### PR TITLE
Add Linux onboarding flows to spider CLI

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -301,6 +301,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const android_targets = android.standardTargets(b, target);
     const build_android = android_targets.len > 0;
+    const cli_only = b.option(bool, "cli-only", "Build only the spider CLI and skip GUI dependencies") orelse false;
     const git_revision = detectGitRevision(b);
     const terminal_backend_option = b.option(
         []const u8,
@@ -339,40 +340,6 @@ pub fn build(b: *std.Build) void {
     const os_tag = target.result.os.tag;
     const spider_protocol_module = spider_node.module("spider-protocol");
 
-    const ziggy_ui = b.dependency("ziggy_ui", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const zgpu = ziggy_ui.builder.dependency("zgpu", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const freetype = b.dependency("freetype", .{
-        .target = target,
-        .optimize = optimize,
-        .enable_brotli = false,
-    });
-
-    const sdl3 = b.dependency("sdl3", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const ziggy_ui_module = ziggy_ui.module("ziggy-ui");
-    const ziggy_ui_src = ziggy_ui.path("src");
-    ziggy_ui_module.addIncludePath(ziggy_ui_src);
-    ziggy_ui_module.addImport("zgpu", zgpu.module("root"));
-
-    const zsc_bridge_module = b.createModule(.{
-        .root_source_file = b.path("src/gui/zsc_bridge.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    zsc_bridge_module.addIncludePath(sdl3.path("include"));
-    ziggy_ui_module.addImport("zsc", zsc_bridge_module);
-    ziggy_ui_module.addIncludePath(freetype.path("include"));
-
     // ---------------------------------------------------------------------
     // CLI executable (default build)
     // ---------------------------------------------------------------------
@@ -404,6 +371,8 @@ pub fn build(b: *std.Build) void {
     const cli_step = b.step("cli", "Build the CLI executable");
     cli_step.dependOn(&cli_install.step);
 
+    if (cli_only) return;
+
     const run_cmd = b.addRunArtifact(cli_exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| run_cmd.addArgs(args);
@@ -417,13 +386,15 @@ pub fn build(b: *std.Build) void {
     const gui_step = b.step("gui", "Build GUI executable for host target");
     const run_gui_step = b.step("run-gui", "Run the GUI app");
 
-    if (addGuiArtifact(b, target, optimize, build_options_module)) |host_gui| {
-        gui_step.dependOn(&host_gui.install.step);
+    if (!cli_only) {
+        if (addGuiArtifact(b, target, optimize, build_options_module)) |host_gui| {
+            gui_step.dependOn(&host_gui.install.step);
 
-        const run_gui_cmd = b.addRunArtifact(host_gui.exe);
-        run_gui_cmd.step.dependOn(&host_gui.install.step);
-        if (b.args) |args| run_gui_cmd.addArgs(args);
-        run_gui_step.dependOn(&run_gui_cmd.step);
+            const run_gui_cmd = b.addRunArtifact(host_gui.exe);
+            run_gui_cmd.step.dependOn(&host_gui.install.step);
+            if (b.args) |args| run_gui_cmd.addArgs(args);
+            run_gui_step.dependOn(&run_gui_cmd.step);
+        }
     }
 
     if (build_android) {

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -21,6 +21,8 @@ pub const Noun = enum {
     agent,
     session,
     node,
+    server,
+    local_node,
     workspace,
     package,
     auth,
@@ -34,6 +36,7 @@ pub const Noun = enum {
 
 pub const Verb = enum {
     send,
+    connect,
     read,
     write,
     stat,
@@ -49,6 +52,7 @@ pub const Verb = enum {
     resume_job,
     list,
     pending,
+    invite_create,
     attach,
     close,
     approve,
@@ -98,6 +102,7 @@ pub const Options = struct {
     operator_token: ?[]const u8 = null,
     role: ?Role = null,
     interactive: bool = false,
+    interactive_explicit: bool = false,
     verbose: bool = false,
     json: bool = false,
     show_help: bool = false,
@@ -154,6 +159,7 @@ pub fn printHelpForNoun(noun: Noun) void {
         .agent => help_agent,
         .session => help_session,
         .node => help_node,
+        .server, .local_node => help_connection,
         .workspace => help_workspace,
         .package => help_package,
         .auth => help_auth,
@@ -186,6 +192,8 @@ pub fn parseNoun(arg: []const u8) ?Noun {
     if (std.mem.eql(u8, arg, "agent")) return .agent;
     if (std.mem.eql(u8, arg, "session")) return .session;
     if (std.mem.eql(u8, arg, "node")) return .node;
+    if (std.mem.eql(u8, arg, "server")) return .server;
+    if (std.mem.eql(u8, arg, "local-node")) return .local_node;
     if (std.mem.eql(u8, arg, "workspace")) return .workspace;
     if (std.mem.eql(u8, arg, "package")) return .package;
     if (std.mem.eql(u8, arg, "auth")) return .auth;
@@ -229,6 +237,7 @@ pub fn parseVerb(noun: Noun, arg: []const u8) ?Verb {
             if (std.mem.eql(u8, arg, "list")) return .list;
             if (std.mem.eql(u8, arg, "info")) return .info;
             if (std.mem.eql(u8, arg, "pending")) return .pending;
+            if (std.mem.eql(u8, arg, "invite-create")) return .invite_create;
             if (std.mem.eql(u8, arg, "approve")) return .approve;
             if (std.mem.eql(u8, arg, "deny")) return .deny;
             if (std.mem.eql(u8, arg, "join-request")) return .join_request;
@@ -236,6 +245,18 @@ pub fn parseVerb(noun: Noun, arg: []const u8) ?Verb {
             if (std.mem.eql(u8, arg, "service-upsert")) return .service_upsert;
             if (std.mem.eql(u8, arg, "service-runtime")) return .service_runtime;
             if (std.mem.eql(u8, arg, "watch")) return .watch;
+        },
+        .server => {
+            if (std.mem.eql(u8, arg, "install")) return .install;
+            if (std.mem.eql(u8, arg, "status")) return .status;
+            if (std.mem.eql(u8, arg, "doctor")) return .doctor;
+            if (std.mem.eql(u8, arg, "remove")) return .remove;
+        },
+        .local_node => {
+            if (std.mem.eql(u8, arg, "install")) return .install;
+            if (std.mem.eql(u8, arg, "connect")) return .connect;
+            if (std.mem.eql(u8, arg, "status")) return .status;
+            if (std.mem.eql(u8, arg, "remove")) return .remove;
         },
         .workspace => {
             if (std.mem.eql(u8, arg, "list")) return .list;
@@ -292,6 +313,7 @@ pub fn parseArgs(allocator: std.mem.Allocator) !Options {
 
     if (args.len <= 1) {
         options.interactive = true;
+        options.interactive_explicit = false;
         std.process.argsFree(allocator, args);
         return options;
     }
@@ -368,6 +390,7 @@ pub fn parseArgs(allocator: std.mem.Allocator) !Options {
         }
         if (std.mem.eql(u8, arg, "--interactive") or std.mem.eql(u8, arg, "-i")) {
             options.interactive = true;
+            options.interactive_explicit = true;
             continue;
         }
         if (std.mem.eql(u8, arg, "--verbose")) {

--- a/src/cli/commands/complete.zig
+++ b/src/cli/commands/complete.zig
@@ -44,7 +44,7 @@ const bash_completion =
     \\  words=("${COMP_WORDS[@]}")
     \\
     \\  # Top-level nouns
-    \\  local nouns="chat fs agent session node workspace package auth connect disconnect status help complete"
+    \\  local nouns="chat fs agent session node server local-node workspace package auth connect disconnect status help complete"
     \\
     \\  if [[ ${COMP_CWORD} -eq 1 ]]; then
     \\    COMPREPLY=( $(compgen -W "${nouns}" -- "${cur}") )
@@ -54,7 +54,7 @@ const bash_completion =
     \\  local noun="${words[1]}"
     \\
     \\  # Global flags always available
-    \\  local global_flags="--url --workspace --token --operator-token --role --verbose --json --help --version --interactive"
+    \\  local global_flags="--url --workspace --workspace-token --operator-token --role --verbose --json --help --version --interactive"
     \\
     \\  if [[ ${COMP_CWORD} -eq 2 ]]; then
     \\    case "${noun}" in
@@ -62,7 +62,9 @@ const bash_completion =
     \\      fs)         COMPREPLY=( $(compgen -W "ls read write stat tree ${global_flags}" -- "${cur}") ) ;;
     \\      agent)      COMPREPLY=( $(compgen -W "list info ${global_flags}" -- "${cur}") ) ;;
     \\      session)    COMPREPLY=( $(compgen -W "list status attach resume close history restore ${global_flags}" -- "${cur}") ) ;;
-    \\      node)       COMPREPLY=( $(compgen -W "list info pending approve deny join-request service-get service-upsert service-runtime watch ${global_flags}" -- "${cur}") ) ;;
+    \\      node)       COMPREPLY=( $(compgen -W "list info pending invite-create approve deny join-request service-get service-upsert service-runtime watch ${global_flags}" -- "${cur}") ) ;;
+    \\      server)     COMPREPLY=( $(compgen -W "install status doctor remove ${global_flags}" -- "${cur}") ) ;;
+    \\      local-node) COMPREPLY=( $(compgen -W "install connect status remove ${global_flags}" -- "${cur}") ) ;;
     \\      workspace)  COMPREPLY=( $(compgen -W "list use create up doctor info status template bind mount handoff ${global_flags}" -- "${cur}") ) ;;
     \\      package)    COMPREPLY=( $(compgen -W "list catalog updates update update-all info get install channel-get channel-set channel-clear enable switch disable rollback remove ${global_flags}" -- "${cur}") ) ;;
     \\      auth)       COMPREPLY=( $(compgen -W "status rotate ${global_flags}" -- "${cur}") ) ;;
@@ -134,7 +136,9 @@ const zsh_completion =
     \\        fs)         _arguments '1: :(ls read write stat tree)' ;;
     \\        agent)      _arguments '1: :(list info)' ;;
     \\        session)    _arguments '1: :(list status attach resume close history restore)' ;;
-    \\        node)       _arguments '1: :(list info pending approve deny join-request service-get service-upsert service-runtime watch)' ;;
+    \\        node)       _arguments '1: :(list info pending invite-create approve deny join-request service-get service-upsert service-runtime watch)' ;;
+    \\        server)     _arguments '1: :(install status doctor remove)' ;;
+    \\        local-node) _arguments '1: :(install connect status remove)' ;;
     \\        workspace)  _spider_workspace ;;
     \\        package)    _spider_package ;;
     \\        auth)       _arguments '1: :(status rotate)' ;;
@@ -152,6 +156,8 @@ const zsh_completion =
     \\    'agent:Agent management'
     \\    'session:Session management'
     \\    'node:Node management'
+    \\    'server:Linux Spiderweb host management'
+    \\    'local-node:Linux node onboarding'
     \\    'workspace:Workspace management'
     \\    'package:Package and registry management'
     \\    'auth:Authentication'
@@ -221,7 +227,7 @@ const fish_completion =
     \\# Global flags
     \\complete -c spider -l url           -d 'Server URL' -r
     \\complete -c spider -l workspace     -d 'Workspace ID' -r
-    \\complete -c spider -l token         -d 'Auth token' -r
+    \\complete -c spider -l workspace-token -d 'Workspace token' -r
     \\complete -c spider -l operator-token -d 'Operator token' -r
     \\complete -c spider -l role          -d 'Role (admin|user)' -r -a 'admin user'
     \\complete -c spider -l verbose       -d 'Verbose output'
@@ -236,6 +242,8 @@ const fish_completion =
     \\complete -c spider -n '__fish_use_subcommand' -a agent      -d 'Agent management'
     \\complete -c spider -n '__fish_use_subcommand' -a session    -d 'Session management'
     \\complete -c spider -n '__fish_use_subcommand' -a node       -d 'Node management'
+    \\complete -c spider -n '__fish_use_subcommand' -a server     -d 'Linux Spiderweb host management'
+    \\complete -c spider -n '__fish_use_subcommand' -a local-node -d 'Linux node onboarding'
     \\complete -c spider -n '__fish_use_subcommand' -a workspace  -d 'Workspace management'
     \\complete -c spider -n '__fish_use_subcommand' -a package    -d 'Package and registry management'
     \\complete -c spider -n '__fish_use_subcommand' -a auth       -d 'Authentication'
@@ -274,6 +282,7 @@ const fish_completion =
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a list             -d 'List nodes'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a info             -d 'Node info'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a pending          -d 'List pending join requests'
+    \\complete -c spider -n '__fish_seen_subcommand_from node' -a invite-create    -d 'Create Linux node invite'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a approve          -d 'Approve join request'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a deny             -d 'Deny join request'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a join-request     -d 'Show join request'
@@ -281,6 +290,18 @@ const fish_completion =
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a service-upsert   -d 'Upsert node service'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a service-runtime  -d 'Node service runtime'
     \\complete -c spider -n '__fish_seen_subcommand_from node' -a watch            -d 'Watch node events'
+    \\
+    \\# server verbs
+    \\complete -c spider -n '__fish_seen_subcommand_from server' -a install -d 'Install Spiderweb host'
+    \\complete -c spider -n '__fish_seen_subcommand_from server' -a status  -d 'Show Spiderweb host status'
+    \\complete -c spider -n '__fish_seen_subcommand_from server' -a doctor  -d 'Check Spiderweb host health'
+    \\complete -c spider -n '__fish_seen_subcommand_from server' -a remove  -d 'Remove Spiderweb host service'
+    \\
+    \\# local-node verbs
+    \\complete -c spider -n '__fish_seen_subcommand_from local-node' -a install -d 'Install Linux node scaffolding'
+    \\complete -c spider -n '__fish_seen_subcommand_from local-node' -a connect -d 'Connect this Linux machine'
+    \\complete -c spider -n '__fish_seen_subcommand_from local-node' -a status  -d 'Show Linux node status'
+    \\complete -c spider -n '__fish_seen_subcommand_from local-node' -a remove  -d 'Remove Linux node service'
     \\
     \\# workspace verbs
     \\complete -c spider -n '__fish_seen_subcommand_from workspace' -a list     -d 'List workspaces'

--- a/src/cli/commands/local_node.zig
+++ b/src/cli/commands/local_node.zig
@@ -1,0 +1,595 @@
+const std = @import("std");
+const args = @import("../args.zig");
+const tui = @import("../tui.zig");
+const linux = @import("../linux_support.zig");
+
+const service_name = "spider-node.service";
+const default_port: u16 = 18891;
+
+const ExportEntry = struct {
+    name: []u8,
+    path: []u8,
+    readonly: bool,
+
+    fn deinit(self: *ExportEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.path);
+        self.* = undefined;
+    }
+};
+
+const NodeConfigSnapshot = struct {
+    exists: bool,
+    config_path: []u8,
+    state_file: []u8,
+    control_url: ?[]u8 = null,
+    control_auth_token_present: bool = false,
+    pair_mode: []u8,
+    invite_token: ?[]u8 = null,
+    node_name: []u8,
+    terminal_ids: std.ArrayListUnmanaged([]u8) = .{},
+    exports: std.ArrayListUnmanaged(ExportEntry) = .{},
+
+    fn deinit(self: *NodeConfigSnapshot, allocator: std.mem.Allocator) void {
+        allocator.free(self.config_path);
+        allocator.free(self.state_file);
+        if (self.control_url) |value| allocator.free(value);
+        allocator.free(self.pair_mode);
+        if (self.invite_token) |value| allocator.free(value);
+        allocator.free(self.node_name);
+        for (self.terminal_ids.items) |item| allocator.free(item);
+        self.terminal_ids.deinit(allocator);
+        for (self.exports.items) |*entry| entry.deinit(allocator);
+        self.exports.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+const PairStateSnapshot = struct {
+    node_id: ?[]u8 = null,
+    request_id: ?[]u8 = null,
+
+    fn deinit(self: *PairStateSnapshot, allocator: std.mem.Allocator) void {
+        if (self.node_id) |value| allocator.free(value);
+        if (self.request_id) |value| allocator.free(value);
+        self.* = undefined;
+    }
+};
+
+fn defaultNodeName(allocator: std.mem.Allocator) ![]u8 {
+    var result = try linux.runCommandCapture(allocator, &.{ "hostname" });
+    defer result.deinit(allocator);
+    if (result.ok()) {
+        const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
+        if (trimmed.len > 0) return allocator.dupe(u8, trimmed);
+    }
+    return allocator.dupe(u8, "linux-node");
+}
+
+fn loadNodeConfigSnapshot(allocator: std.mem.Allocator, user: linux.ServiceUser) !NodeConfigSnapshot {
+    const config_path = try linux.resolveLinuxNodeConfigPath(allocator, user);
+    errdefer allocator.free(config_path);
+    const default_state_path = try linux.resolveLinuxNodeStatePath(allocator, user);
+    errdefer allocator.free(default_state_path);
+    const default_name = try defaultNodeName(allocator);
+    errdefer allocator.free(default_name);
+
+    if (!linux.pathExists(config_path)) {
+        return .{
+            .exists = false,
+            .config_path = config_path,
+            .state_file = default_state_path,
+            .pair_mode = try allocator.dupe(u8, "request"),
+            .node_name = default_name,
+        };
+    }
+
+    const payload = try linux.readFileAllocAny(allocator, config_path, 256 * 1024);
+    defer allocator.free(payload);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidResponse;
+
+    var snapshot = NodeConfigSnapshot{
+        .exists = true,
+        .config_path = config_path,
+        .state_file = default_state_path,
+        .pair_mode = try allocator.dupe(u8, "request"),
+        .node_name = default_name,
+    };
+    errdefer snapshot.deinit(allocator);
+
+    const root = parsed.value.object;
+    if (root.get("state_file")) |value| {
+        if (value == .string and value.string.len > 0) {
+            allocator.free(snapshot.state_file);
+            snapshot.state_file = try allocator.dupe(u8, value.string);
+        }
+    }
+    if (root.get("control_url")) |value| {
+        if (value == .string and value.string.len > 0) {
+            snapshot.control_url = try allocator.dupe(u8, value.string);
+        }
+    }
+    if (root.get("control_auth_token")) |value| {
+        if (value == .string and value.string.len > 0) {
+            snapshot.control_auth_token_present = true;
+        }
+    }
+    if (root.get("pair_mode")) |value| {
+        if (value == .string and value.string.len > 0) {
+            allocator.free(snapshot.pair_mode);
+            snapshot.pair_mode = try allocator.dupe(u8, value.string);
+        }
+    }
+    if (root.get("invite_token")) |value| {
+        if (value == .string and value.string.len > 0) {
+            snapshot.invite_token = try allocator.dupe(u8, value.string);
+        }
+    }
+    if (root.get("node_name")) |value| {
+        if (value == .string and value.string.len > 0) {
+            allocator.free(snapshot.node_name);
+            snapshot.node_name = try allocator.dupe(u8, value.string);
+        }
+    }
+    if (root.get("terminal_ids")) |value| {
+        if (value == .array) {
+            for (value.array.items) |entry| {
+                if (entry != .string or entry.string.len == 0) continue;
+                try snapshot.terminal_ids.append(allocator, try allocator.dupe(u8, entry.string));
+            }
+        }
+    }
+    if (root.get("exports")) |value| {
+        if (value == .array) {
+            for (value.array.items) |entry| {
+                if (entry != .object) continue;
+                const name_val = entry.object.get("name") orelse continue;
+                const path_val = entry.object.get("path") orelse continue;
+                if (name_val != .string or path_val != .string) continue;
+                try snapshot.exports.append(allocator, .{
+                    .name = try allocator.dupe(u8, name_val.string),
+                    .path = try allocator.dupe(u8, path_val.string),
+                    .readonly = if (entry.object.get("readonly")) |readonly|
+                        readonly == .bool and readonly.bool
+                    else
+                        false,
+                });
+            }
+        }
+    }
+    if (snapshot.terminal_ids.items.len == 0) {
+        try snapshot.terminal_ids.append(allocator, try allocator.dupe(u8, "main"));
+    }
+    return snapshot;
+}
+
+fn loadPairState(allocator: std.mem.Allocator, state_path: []const u8) !PairStateSnapshot {
+    if (!linux.pathExists(state_path)) return .{};
+    const payload = try linux.readFileAllocAny(allocator, state_path, 128 * 1024);
+    defer allocator.free(payload);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return .{};
+
+    var snapshot = PairStateSnapshot{};
+    errdefer snapshot.deinit(allocator);
+    if (parsed.value.object.get("node_id")) |value| {
+        if (value == .string and value.string.len > 0) snapshot.node_id = try allocator.dupe(u8, value.string);
+    }
+    if (parsed.value.object.get("request_id")) |value| {
+        if (value == .string and value.string.len > 0) snapshot.request_id = try allocator.dupe(u8, value.string);
+    }
+    return snapshot;
+}
+
+fn writeSystemServiceUnit(
+    allocator: std.mem.Allocator,
+    user: linux.ServiceUser,
+    fs_node_bin: []const u8,
+    config_path: []const u8,
+    working_dir: []const u8,
+) !void {
+    const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
+    defer allocator.free(unit_path);
+    try linux.ensureParentPath(unit_path);
+    const payload = try std.fmt.allocPrint(
+        allocator,
+        \\[Unit]
+        \\Description=Spider Linux Node
+        \\After=network.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\User={s}
+        \\Environment=HOME={s}
+        \\Environment=XDG_CONFIG_HOME={s}
+        \\ExecStart={s} --config {s}
+        \\WorkingDirectory={s}
+        \\Restart=on-failure
+        \\RestartSec=5
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    ,
+        .{ user.name, user.home, user.config_home, fs_node_bin, config_path, working_dir },
+    );
+    defer allocator.free(payload);
+    try linux.writeFileAny(unit_path, payload);
+}
+
+fn writeNodeConfig(
+    allocator: std.mem.Allocator,
+    config_path: []const u8,
+    state_path: []const u8,
+    control_url: []const u8,
+    control_auth_token: ?[]const u8,
+    pair_mode: []const u8,
+    invite_token: ?[]const u8,
+    node_name: []const u8,
+    exports: []const []const u8,
+) !void {
+    var payload = std.ArrayListUnmanaged(u8){};
+    defer payload.deinit(allocator);
+    try payload.writer(allocator).writeAll("{\n");
+    try payload.writer(allocator).print("  \"bind\": \"127.0.0.1\",\n", .{});
+    try payload.writer(allocator).print("  \"port\": {d},\n", .{default_port});
+    try payload.writer(allocator).print("  \"control_url\": \"{s}\",\n", .{control_url});
+    if (control_auth_token) |token| {
+        try payload.writer(allocator).print("  \"control_auth_token\": \"{s}\",\n", .{token});
+    }
+    try payload.writer(allocator).print("  \"pair_mode\": \"{s}\",\n", .{pair_mode});
+    if (invite_token) |token| {
+        try payload.writer(allocator).print("  \"invite_token\": \"{s}\",\n", .{token});
+    }
+    try payload.writer(allocator).print("  \"node_name\": \"{s}\",\n", .{node_name});
+    try payload.writer(allocator).print("  \"state_file\": \"{s}\",\n", .{state_path});
+    try payload.writer(allocator).writeAll("  \"enable_fs_venom\": false,\n");
+    try payload.writer(allocator).writeAll("  \"terminal_ids\": [\"main\"],\n");
+    try payload.writer(allocator).writeAll("  \"exports\": [");
+    for (exports, 0..) |path, idx| {
+        if (idx > 0) try payload.writer(allocator).writeAll(",");
+        const base_name = std.fs.path.basename(path);
+        try payload.writer(allocator).print(
+            "\n    {{\"name\":\"{s}\",\"path\":\"{s}\",\"readonly\":false}}",
+            .{ if (base_name.len > 0) base_name else "export", path },
+        );
+    }
+    if (exports.len > 0) try payload.writer(allocator).writeAll("\n");
+    try payload.writer(allocator).writeAll("  ]\n}\n");
+    try linux.writeFileAny(config_path, payload.items);
+}
+
+fn ensureInstallScaffold(allocator: std.mem.Allocator) !struct { user: linux.ServiceUser, config_path: []u8, state_path: []u8 } {
+    var user = try linux.resolveServiceUser(allocator);
+    errdefer user.deinit(allocator);
+    const config_path = try linux.resolveLinuxNodeConfigPath(allocator, user);
+    errdefer allocator.free(config_path);
+    const state_path = try linux.resolveLinuxNodeStatePath(allocator, user);
+    errdefer allocator.free(state_path);
+    const working_dir = try linux.resolveSpiderConfigDir(allocator, user);
+    defer allocator.free(working_dir);
+
+    try linux.makePathAny(working_dir);
+    try linux.ensureOwnedByServiceUser(allocator, user, working_dir);
+
+    if (!linux.pathExists(config_path)) {
+        const default_name = try defaultNodeName(allocator);
+        defer allocator.free(default_name);
+        try writeNodeConfig(allocator, config_path, state_path, "", null, "request", null, default_name, &.{});
+        try linux.ensureOwnedByServiceUser(allocator, user, working_dir);
+    }
+
+    const fs_node_bin = try linux.resolveInstalledBinary(allocator, "spiderweb-fs-node");
+    defer allocator.free(fs_node_bin);
+
+    if (user.scope == .system) {
+        try writeSystemServiceUnit(allocator, user, fs_node_bin, config_path, working_dir);
+        var reload = try linux.systemctlAction(allocator, user, &.{ "daemon-reload" });
+        defer reload.deinit(allocator);
+        if (!reload.ok()) return error.CommandFailed;
+    } else {
+        const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
+        defer allocator.free(unit_path);
+        const payload = try std.fmt.allocPrint(
+            allocator,
+            \\[Unit]
+            \\Description=Spider Linux Node
+            \\After=network.target
+            \\
+            \\[Service]
+            \\Type=simple
+            \\ExecStart={s} --config {s}
+            \\WorkingDirectory={s}
+            \\Restart=on-failure
+            \\RestartSec=5
+            \\
+            \\[Install]
+            \\WantedBy=default.target
+            \\
+        ,
+            .{ fs_node_bin, config_path, working_dir },
+        );
+        defer allocator.free(payload);
+        try linux.writeFileAny(unit_path, payload);
+        var reload = try linux.systemctlAction(allocator, user, &.{ "daemon-reload" });
+        defer reload.deinit(allocator);
+        if (!reload.ok()) return error.CommandFailed;
+    }
+
+    return .{ .user = user, .config_path = config_path, .state_path = state_path };
+}
+
+pub fn executeLocalNodeInstall(allocator: std.mem.Allocator, _: args.Options, cmd: args.Command) !void {
+    if (cmd.args.len != 0) return error.InvalidArguments;
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var install = try ensureInstallScaffold(allocator);
+    defer install.user.deinit(allocator);
+    defer allocator.free(install.config_path);
+    defer allocator.free(install.state_path);
+    try stdout.print("Linux node scaffolding is ready\n", .{});
+    try stdout.print("  Managed user: {s}\n", .{install.user.name});
+    try stdout.print("  Service scope: {s}\n", .{if (install.user.scope == .system) "systemd system" else "systemd user"});
+    try stdout.print("  Config: {s}\n", .{install.config_path});
+    try stdout.print("  Next: spider local-node connect --control-url ws://host:18790/ --request-approval\n", .{});
+}
+
+pub fn executeLocalNodeConnect(allocator: std.mem.Allocator, _: args.Options, cmd: args.Command) !void {
+    var control_url: ?[]const u8 = null;
+    var control_auth_token: ?[]const u8 = null;
+    var prompted_control_auth_token = false;
+    var invite_token: ?[]const u8 = null;
+    var node_name: ?[]const u8 = null;
+    var exports = std.ArrayListUnmanaged([]u8){};
+    defer {
+        for (exports.items) |item| allocator.free(item);
+        exports.deinit(allocator);
+    }
+    var prompted_control_url = false;
+
+    var i: usize = 0;
+    while (i < cmd.args.len) : (i += 1) {
+        const arg = cmd.args[i];
+        if (std.mem.eql(u8, arg, "--control-url")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            control_url = cmd.args[i];
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--invite-token")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            invite_token = cmd.args[i];
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--control-auth-token")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            control_auth_token = cmd.args[i];
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--request-approval")) {
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--node-name")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            node_name = cmd.args[i];
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--export")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            try exports.append(allocator, try allocator.dupe(u8, cmd.args[i]));
+            continue;
+        }
+        return error.InvalidArguments;
+    }
+
+    if (control_url == null and std.fs.File.stdin().isTty()) {
+        control_url = try tui.prompt(allocator, "Remote Spiderweb URL", "ws://127.0.0.1:18790/");
+        prompted_control_url = true;
+    }
+    const target_url = control_url orelse return error.InvalidArguments;
+    defer if (prompted_control_url) allocator.free(target_url);
+
+    const pair_mode = if (invite_token != null) "invite" else "request";
+
+    const chosen_name = if (node_name) |value|
+        try allocator.dupe(u8, value)
+    else if (std.fs.File.stdin().isTty())
+        try tui.prompt(allocator, "Node name", "linux-node")
+    else
+        try allocator.dupe(u8, "linux-node");
+    defer allocator.free(chosen_name);
+
+    if (control_auth_token == null and std.fs.File.stdin().isTty()) {
+        const prompted_token = try tui.prompt(allocator, "Remote Spiderweb access token (optional)", null);
+        if (prompted_token.len == 0) {
+            allocator.free(prompted_token);
+        } else {
+            control_auth_token = prompted_token;
+            prompted_control_auth_token = true;
+        }
+    }
+    defer if (prompted_control_auth_token) allocator.free(control_auth_token.?);
+
+    if (std.fs.File.stdin().isTty()) {
+        while (try tui.confirm("Add an export path for this node?", false)) {
+            const export_path = try tui.prompt(allocator, "Export path", null);
+            if (export_path.len == 0) {
+                allocator.free(export_path);
+                break;
+            }
+            try exports.append(allocator, export_path);
+        }
+    }
+
+    var install = try ensureInstallScaffold(allocator);
+    defer install.user.deinit(allocator);
+    defer allocator.free(install.config_path);
+    defer allocator.free(install.state_path);
+
+    try writeNodeConfig(
+        allocator,
+        install.config_path,
+        install.state_path,
+        target_url,
+        control_auth_token,
+        if (invite_token != null) "invite" else "request",
+        invite_token,
+        chosen_name,
+        exports.items,
+    );
+    const working_dir = try linux.resolveSpiderConfigDir(allocator, install.user);
+    defer allocator.free(working_dir);
+    try linux.ensureOwnedByServiceUser(allocator, install.user, working_dir);
+
+    var enable_now = try linux.systemctlAction(allocator, install.user, &.{ "enable", "--now", service_name });
+    defer enable_now.deinit(allocator);
+    if (!enable_now.ok()) return error.CommandFailed;
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    std.Thread.sleep(1 * std.time.ns_per_s);
+    const service_state = try linux.systemdState(allocator, install.user, service_name);
+    var pair_state = try loadPairState(allocator, install.state_path);
+    defer pair_state.deinit(allocator);
+
+    try stdout.print("Linux node is configured\n", .{});
+    try stdout.print("  Managed user: {s}\n", .{install.user.name});
+    try stdout.print("  Service scope: {s}\n", .{if (install.user.scope == .system) "systemd system" else "systemd user"});
+    try stdout.print("  Control URL: {s}\n", .{target_url});
+    try stdout.print("  Pair mode: {s}\n", .{pair_mode});
+    try stdout.print("  Node name: {s}\n", .{chosen_name});
+    try stdout.print("  Access token: {s}\n", .{if (control_auth_token != null) "configured" else "not provided"});
+    try stdout.print("  Terminal: Workspace Shell enabled by default\n", .{});
+    try stdout.print("  Service: {s}\n", .{if (service_state.active) "active" else "starting or failed"});
+    if (pair_state.node_id) |node_id| {
+        try stdout.print("  Pairing: connected as {s}\n", .{node_id});
+    } else if (pair_state.request_id) |request_id| {
+        try stdout.print("  Pairing: waiting for approval ({s})\n", .{request_id});
+    } else {
+        try stdout.print("  Pairing: pending service startup\n", .{});
+    }
+    if (exports.items.len == 0) {
+        try stdout.print("  Exports: none\n", .{});
+    } else {
+        try stdout.print("  Exports:\n", .{});
+        for (exports.items) |path| try stdout.print("    - {s}\n", .{path});
+    }
+    if (pair_state.node_id == null) {
+        try stdout.print("  Host next step: spider node pending\n", .{});
+        try stdout.print("  Host approve: spider node approve <request-id>\n", .{});
+    }
+}
+
+pub fn executeLocalNodeStatus(allocator: std.mem.Allocator, _: args.Options, cmd: args.Command) !void {
+    if (cmd.args.len != 0) return error.InvalidArguments;
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var user = try linux.resolveServiceUser(allocator);
+    defer user.deinit(allocator);
+    var config = try loadNodeConfigSnapshot(allocator, user);
+    defer config.deinit(allocator);
+    var pair_state = try loadPairState(allocator, config.state_file);
+    defer pair_state.deinit(allocator);
+    const service_state = try linux.systemdState(allocator, user, service_name);
+
+    try stdout.print("Linux node status\n", .{});
+    try stdout.print("  Managed user: {s}\n", .{user.name});
+    try stdout.print("  Service scope: {s}\n", .{if (user.scope == .system) "systemd system" else "systemd user"});
+    try stdout.print("  Service installed: {s}\n", .{if (service_state.installed) "yes" else "no"});
+    try stdout.print("  Service active: {s}\n", .{if (service_state.active) "yes" else "no"});
+    try stdout.print("  Config: {s}\n", .{config.config_path});
+    try stdout.print("  State file: {s}\n", .{config.state_file});
+    try stdout.print("  Control URL: {s}\n", .{config.control_url orelse "(not configured)"});
+    try stdout.print("  Access token: {s}\n", .{if (config.control_auth_token_present) "configured" else "not configured"});
+    try stdout.print("  Pair mode: {s}\n", .{config.pair_mode});
+    try stdout.print("  Pairing: {s}\n", .{
+        if (pair_state.node_id != null) "connected"
+        else if (pair_state.request_id != null) "waiting for approval"
+        else "not paired",
+    });
+    if (pair_state.node_id) |node_id| try stdout.print("  Node ID: {s}\n", .{node_id});
+    if (pair_state.request_id) |request_id| try stdout.print("  Request ID: {s}\n", .{request_id});
+    try stdout.print("  Node name: {s}\n", .{config.node_name});
+    try stdout.print("  Terminal published: {s}\n", .{if (config.terminal_ids.items.len > 0) "yes" else "no"});
+    if (config.exports.items.len == 0) {
+        try stdout.print("  Exports: none\n", .{});
+    } else {
+        try stdout.print("  Exports:\n", .{});
+        for (config.exports.items) |entry| {
+            try stdout.print("    - {s} => {s}\n", .{ entry.name, entry.path });
+        }
+    }
+    if (!service_state.active) {
+        try stdout.print("  Suggested next step: spider local-node connect --control-url ws://host:18790/ --request-approval\n", .{});
+    }
+}
+
+pub fn executeLocalNodeRemove(allocator: std.mem.Allocator, _: args.Options, cmd: args.Command) !void {
+    if (cmd.args.len != 0) return error.InvalidArguments;
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var user = try linux.resolveServiceUser(allocator);
+    defer user.deinit(allocator);
+    const config_path = try linux.resolveLinuxNodeConfigPath(allocator, user);
+    defer allocator.free(config_path);
+    const state_path = try linux.resolveLinuxNodeStatePath(allocator, user);
+    defer allocator.free(state_path);
+    const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
+    defer allocator.free(unit_path);
+
+    var disable = try linux.systemctlAction(allocator, user, &.{ "disable", "--now", service_name });
+    defer disable.deinit(allocator);
+    if (linux.pathExists(unit_path)) {
+        if (std.fs.path.isAbsolute(unit_path)) std.fs.deleteFileAbsolute(unit_path) catch {} else std.fs.cwd().deleteFile(unit_path) catch {};
+    }
+    if (linux.pathExists(config_path)) {
+        if (std.fs.path.isAbsolute(config_path)) std.fs.deleteFileAbsolute(config_path) catch {} else std.fs.cwd().deleteFile(config_path) catch {};
+    }
+    if (linux.pathExists(state_path)) {
+        if (std.fs.path.isAbsolute(state_path)) std.fs.deleteFileAbsolute(state_path) catch {} else std.fs.cwd().deleteFile(state_path) catch {};
+    }
+    var reload = try linux.systemctlAction(allocator, user, &.{ "daemon-reload" });
+    defer reload.deinit(allocator);
+    try stdout.print("Linux node service and local config removed.\n", .{});
+    try stdout.print("Remote node registrations on Spiderweb were left in place.\n", .{});
+}
+
+pub fn runConnectWizard(allocator: std.mem.Allocator) !void {
+    tui.printInfo("This Linux machine will connect to another Spiderweb as a node.");
+    const control_url = try tui.prompt(allocator, "Remote Spiderweb URL", "ws://127.0.0.1:18790/");
+    defer allocator.free(control_url);
+    const control_auth_token = try tui.prompt(allocator, "Remote Spiderweb access token", null);
+    defer allocator.free(control_auth_token);
+    const invite = try tui.confirm("Use an invite token instead of request/approve?", false);
+    var invite_token: ?[]u8 = null;
+    defer if (invite_token) |value| allocator.free(value);
+    if (invite) {
+        invite_token = try tui.prompt(allocator, "Invite token", null);
+    }
+    const node_name = try tui.prompt(allocator, "Node name", "linux-node");
+    defer allocator.free(node_name);
+
+    const fake_args = args.Command{
+        .noun = .local_node,
+        .verb = .connect,
+        .args = &.{ "--control-url", control_url, if (invite) "--invite-token" else "--request-approval", if (invite) invite_token.? else "" },
+    };
+    _ = fake_args;
+    // Run the real command path with the gathered defaults so the wizard
+    // stays thin and the non-interactive command remains canonical.
+    var cmd_args = std.ArrayListUnmanaged([]const u8){};
+    defer cmd_args.deinit(allocator);
+    try cmd_args.appendSlice(allocator, &.{ "--control-url", control_url, "--node-name", node_name });
+    if (control_auth_token.len > 0) {
+        try cmd_args.appendSlice(allocator, &.{ "--control-auth-token", control_auth_token });
+    }
+    if (invite) {
+        try cmd_args.appendSlice(allocator, &.{ "--invite-token", invite_token.? });
+    } else {
+        try cmd_args.append(allocator, "--request-approval");
+    }
+    try executeLocalNodeConnect(allocator, .{}, .{ .noun = .local_node, .verb = .connect, .args = cmd_args.items });
+}

--- a/src/cli/commands/local_node.zig
+++ b/src/cli/commands/local_node.zig
@@ -6,6 +6,26 @@ const linux = @import("../linux_support.zig");
 const service_name = "spider-node.service";
 const default_port: u16 = 18891;
 
+const NodeConfigFile = struct {
+    bind: []const u8,
+    port: u16,
+    control_url: []const u8,
+    control_auth_token: ?[]const u8 = null,
+    pair_mode: []const u8,
+    invite_token: ?[]const u8 = null,
+    node_name: []const u8,
+    state_file: []const u8,
+    enable_fs_venom: bool,
+    terminal_ids: []const []const u8,
+    exports: []const NodeConfigExport,
+};
+
+const NodeConfigExport = struct {
+    name: []const u8,
+    path: []const u8,
+    readonly: bool,
+};
+
 const ExportEntry = struct {
     name: []u8,
     path: []u8,
@@ -231,35 +251,37 @@ fn writeNodeConfig(
     node_name: []const u8,
     exports: []const []const u8,
 ) !void {
-    var payload = std.ArrayListUnmanaged(u8){};
-    defer payload.deinit(allocator);
-    try payload.writer(allocator).writeAll("{\n");
-    try payload.writer(allocator).print("  \"bind\": \"127.0.0.1\",\n", .{});
-    try payload.writer(allocator).print("  \"port\": {d},\n", .{default_port});
-    try payload.writer(allocator).print("  \"control_url\": \"{s}\",\n", .{control_url});
-    if (control_auth_token) |token| {
-        try payload.writer(allocator).print("  \"control_auth_token\": \"{s}\",\n", .{token});
-    }
-    try payload.writer(allocator).print("  \"pair_mode\": \"{s}\",\n", .{pair_mode});
-    if (invite_token) |token| {
-        try payload.writer(allocator).print("  \"invite_token\": \"{s}\",\n", .{token});
-    }
-    try payload.writer(allocator).print("  \"node_name\": \"{s}\",\n", .{node_name});
-    try payload.writer(allocator).print("  \"state_file\": \"{s}\",\n", .{state_path});
-    try payload.writer(allocator).writeAll("  \"enable_fs_venom\": false,\n");
-    try payload.writer(allocator).writeAll("  \"terminal_ids\": [\"main\"],\n");
-    try payload.writer(allocator).writeAll("  \"exports\": [");
+    const terminal_ids = [_][]const u8{ "main" };
+    var export_entries = try allocator.alloc(NodeConfigExport, exports.len);
+    defer allocator.free(export_entries);
     for (exports, 0..) |path, idx| {
-        if (idx > 0) try payload.writer(allocator).writeAll(",");
         const base_name = std.fs.path.basename(path);
-        try payload.writer(allocator).print(
-            "\n    {{\"name\":\"{s}\",\"path\":\"{s}\",\"readonly\":false}}",
-            .{ if (base_name.len > 0) base_name else "export", path },
-        );
+        export_entries[idx] = .{
+            .name = if (base_name.len > 0) base_name else "export",
+            .path = path,
+            .readonly = false,
+        };
     }
-    if (exports.len > 0) try payload.writer(allocator).writeAll("\n");
-    try payload.writer(allocator).writeAll("  ]\n}\n");
-    try linux.writeFileAny(config_path, payload.items);
+
+    const payload = try std.json.Stringify.valueAlloc(
+        allocator,
+        NodeConfigFile{
+            .bind = "127.0.0.1",
+            .port = default_port,
+            .control_url = control_url,
+            .control_auth_token = control_auth_token,
+            .pair_mode = pair_mode,
+            .invite_token = invite_token,
+            .node_name = node_name,
+            .state_file = state_path,
+            .enable_fs_venom = false,
+            .terminal_ids = &terminal_ids,
+            .exports = export_entries,
+        },
+        .{ .whitespace = .indent_2 },
+    );
+    defer allocator.free(payload);
+    try linux.writeFileAny(config_path, payload);
 }
 
 fn ensureInstallScaffold(allocator: std.mem.Allocator) !struct { user: linux.ServiceUser, config_path: []u8, state_path: []u8 } {
@@ -592,4 +614,33 @@ pub fn runConnectWizard(allocator: std.mem.Allocator) !void {
         try cmd_args.append(allocator, "--request-approval");
     }
     try executeLocalNodeConnect(allocator, .{}, .{ .noun = .local_node, .verb = .connect, .args = cmd_args.items });
+}
+
+test "writeNodeConfig escapes user-provided JSON strings" {
+    const allocator = std.testing.allocator;
+    const temp_dir = std.testing.tmpDir(.{});
+    defer temp_dir.cleanup();
+
+    const config_path = try std.fs.path.join(allocator, &.{ temp_dir.dir_path, "linux-node.json" });
+    defer allocator.free(config_path);
+
+    const exports = [_][]const u8{ "/tmp/export\"quote" };
+    try writeNodeConfig(
+        allocator,
+        config_path,
+        "/tmp/state\"file.json",
+        "ws://host/\"quoted\"",
+        "token-with-quote-\"-and-backslash-\\",
+        "invite",
+        "invite-\"token\"",
+        "node-\"name\"",
+        &exports,
+    );
+
+    const payload = try linux.readFileAllocAny(allocator, config_path, 64 * 1024);
+    defer allocator.free(payload);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value == .object);
 }

--- a/src/cli/commands/node.zig
+++ b/src/cli/commands/node.zig
@@ -445,6 +445,93 @@ pub fn executeNodePendingList(allocator: std.mem.Allocator, options: args.Option
     }
 }
 
+pub fn executeNodeInviteCreate(allocator: std.mem.Allocator, options: args.Options, cmd: args.Command) !void {
+    var expires_in_ms: ?u64 = null;
+    var node_name: ?[]const u8 = null;
+
+    var i: usize = 0;
+    while (i < cmd.args.len) : (i += 1) {
+        const arg = cmd.args[i];
+        if (std.mem.eql(u8, arg, "--expires-in-ms")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            expires_in_ms = try std.fmt.parseInt(u64, cmd.args[i], 10);
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--node-name")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            node_name = cmd.args[i];
+            continue;
+        }
+        return error.InvalidArguments;
+    }
+
+    var cfg = try ctx.loadCliConfig(allocator);
+    defer cfg.deinit();
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    const client = try ctx.getOrCreateClient(allocator, options);
+    try ctx.ensureUnifiedV2Control(allocator, client);
+
+    var payload = std.ArrayListUnmanaged(u8){};
+    defer payload.deinit(allocator);
+    try payload.append(allocator, '{');
+    var appended = false;
+    if (expires_in_ms) |value| {
+        try payload.writer(allocator).print("\"expires_in_ms\":{d}", .{value});
+        appended = true;
+    }
+    if (node_name) |value| {
+        const escaped_name = try unified.jsonEscape(allocator, value);
+        defer allocator.free(escaped_name);
+        if (appended) try payload.append(allocator, ',');
+        try payload.writer(allocator).print("\"node_name\":\"{s}\"", .{escaped_name});
+        appended = true;
+    }
+    if (resolveOperatorToken(options, &cfg)) |token| {
+        const escaped_token = try unified.jsonEscape(allocator, token);
+        defer allocator.free(escaped_token);
+        if (appended) try payload.append(allocator, ',');
+        try payload.writer(allocator).print("\"operator_token\":\"{s}\"", .{escaped_token});
+    }
+    try payload.append(allocator, '}');
+
+    const payload_json = try control_plane.requestControlPayloadJson(
+        allocator,
+        client,
+        &ctx.g_control_request_counter,
+        "control.node_invite_create",
+        payload.items,
+    );
+    defer allocator.free(payload_json);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, payload_json, .{}) catch {
+        try stdout.print("{s}\n", .{payload_json});
+        return;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) {
+        try stdout.print("{s}\n", .{payload_json});
+        return;
+    }
+
+    const root = parsed.value.object;
+    const invite_token = jsonObjectStringOr(root, "invite_token", "(missing)");
+    try stdout.print("Linux node invite created\n", .{});
+    try stdout.print("  Invite ID: {s}\n", .{jsonObjectStringOr(root, "invite_id", "(unknown)")});
+    try stdout.print("  Invite token: {s}\n", .{invite_token});
+    try stdout.print("  Expires at: {d}\n", .{jsonObjectI64Or(root, "expires_at_ms", 0)});
+    try stdout.print(
+        "  Connect command: spider local-node connect --control-url {s} --invite-token {s}\n",
+        .{ options.url, invite_token },
+    );
+    try stdout.print(
+        "  If Spiderweb auth is enabled, also add: --control-auth-token <server-access-token>\n",
+        .{},
+    );
+}
+
 pub fn executeNodeApprove(allocator: std.mem.Allocator, options: args.Options, cmd: args.Command) !void {
     if (cmd.args.len == 0) {
         logger.err("node approve requires <request_id>", .{});

--- a/src/cli/commands/server.zig
+++ b/src/cli/commands/server.zig
@@ -1,0 +1,409 @@
+const std = @import("std");
+const args = @import("../args.zig");
+const tui = @import("../tui.zig");
+const linux = @import("../linux_support.zig");
+
+const default_bind = "0.0.0.0";
+const default_port: u16 = 18790;
+const service_name = "spiderweb.service";
+
+const ConfigSnapshot = struct {
+    exists: bool,
+    config_path: []u8,
+    bind: []u8,
+    port: u16,
+    spider_web_root: []u8,
+    state_directory: []u8,
+
+    fn deinit(self: *ConfigSnapshot, allocator: std.mem.Allocator) void {
+        allocator.free(self.config_path);
+        allocator.free(self.bind);
+        allocator.free(self.spider_web_root);
+        allocator.free(self.state_directory);
+        self.* = undefined;
+    }
+};
+
+const StatusSnapshot = struct {
+    user: linux.ServiceUser,
+    config: ConfigSnapshot,
+    auth_present: bool,
+    runtime_assets_present: bool,
+    local_node_binary_present: bool,
+    node_service_installed: bool,
+    node_service_active: bool,
+    service_installed: bool,
+    service_enabled: bool,
+    service_active: bool,
+
+    fn deinit(self: *StatusSnapshot, allocator: std.mem.Allocator) void {
+        self.user.deinit(allocator);
+        self.config.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+fn loadConfigSnapshot(allocator: std.mem.Allocator, user: linux.ServiceUser) !ConfigSnapshot {
+    const config_path = try linux.resolveSpiderwebConfigPath(allocator, user);
+    errdefer allocator.free(config_path);
+    if (!linux.pathExists(config_path)) {
+        return .{
+            .exists = false,
+            .config_path = config_path,
+            .bind = try allocator.dupe(u8, default_bind),
+            .port = default_port,
+            .spider_web_root = try std.fs.path.join(allocator, &.{ user.home, "Spiderweb" }),
+            .state_directory = try allocator.dupe(u8, ".spiderweb-state"),
+        };
+    }
+
+    const payload = try linux.readFileAllocAny(allocator, config_path, 256 * 1024);
+    defer allocator.free(payload);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+    defer parsed.deinit();
+
+    const root = if (parsed.value == .object) parsed.value.object else return error.InvalidResponse;
+    const server = root.get("server") orelse return error.InvalidResponse;
+    const runtime = root.get("runtime") orelse return error.InvalidResponse;
+
+    const bind = if (server == .object)
+        if (server.object.get("bind")) |value|
+            if (value == .string) value.string else default_bind
+        else
+            default_bind
+    else
+        default_bind;
+    const port = if (server == .object)
+        if (server.object.get("port")) |value|
+            switch (value) {
+                .integer => if (value.integer > 0) @as(u16, @intCast(value.integer)) else default_port,
+                else => default_port,
+            }
+        else
+            default_port
+    else
+        default_port;
+    const spider_web_root = if (runtime == .object)
+        if (runtime.object.get("spider_web_root")) |value|
+            if (value == .string and value.string.len > 0) value.string else ""
+        else
+            ""
+    else
+        "";
+    const state_directory = if (runtime == .object)
+        if (runtime.object.get("state_directory")) |value|
+            if (value == .string and value.string.len > 0) value.string else ".spiderweb-state"
+        else
+            ".spiderweb-state"
+    else
+        ".spiderweb-state";
+
+    return .{
+        .exists = true,
+        .config_path = config_path,
+        .bind = try allocator.dupe(u8, bind),
+        .port = port,
+        .spider_web_root = if (spider_web_root.len > 0)
+            try allocator.dupe(u8, spider_web_root)
+        else
+            try std.fs.path.join(allocator, &.{ user.home, "Spiderweb" }),
+        .state_directory = try allocator.dupe(u8, state_directory),
+    };
+}
+
+fn loadAuthPresence(
+    allocator: std.mem.Allocator,
+    user: linux.ServiceUser,
+    spiderweb_config_bin: []const u8,
+) !bool {
+    var argv = std.ArrayListUnmanaged([]const u8){};
+    defer argv.deinit(allocator);
+    try argv.appendSlice(allocator, &.{ spiderweb_config_bin, "auth", "status", "--json" });
+    var result = try linux.runCommandAsServiceUser(allocator, user, argv.items);
+    defer result.deinit(allocator);
+    if (!result.ok()) return false;
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, result.stdout, .{}) catch return false;
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    const access_present = parsed.value.object.get("access_present") orelse return false;
+    return access_present == .bool and access_present.bool;
+}
+
+fn ensureAuthPresent(
+    allocator: std.mem.Allocator,
+    user: linux.ServiceUser,
+    spiderweb_config_bin: []const u8,
+) !bool {
+    if (try loadAuthPresence(allocator, user, spiderweb_config_bin)) return false;
+    var argv = std.ArrayListUnmanaged([]const u8){};
+    defer argv.deinit(allocator);
+    try argv.appendSlice(allocator, &.{ spiderweb_config_bin, "auth", "reset", "--yes" });
+    var result = try linux.runCommandAsServiceUser(allocator, user, argv.items);
+    defer result.deinit(allocator);
+    if (!result.ok()) return error.CommandFailed;
+    return true;
+}
+
+fn runtimeAssetsPresent(allocator: std.mem.Allocator, spiderweb_bin: []const u8) !bool {
+    const bin_dir = std.fs.path.dirname(spiderweb_bin) orelse return false;
+    const prefix = std.fs.path.dirname(bin_dir) orelse return false;
+    const templates = try std.fs.path.join(allocator, &.{ prefix, "share", "spiderweb", "templates" });
+    defer allocator.free(templates);
+    const venoms = try std.fs.path.join(allocator, &.{ prefix, "share", "spidervenoms", "bundles", "managed-local", "release.json" });
+    defer allocator.free(venoms);
+    return linux.pathExists(templates) and linux.pathExists(venoms);
+}
+
+fn writeSystemServiceUnit(
+    allocator: std.mem.Allocator,
+    user: linux.ServiceUser,
+    spiderweb_bin: []const u8,
+    working_dir: []const u8,
+) !void {
+    const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
+    defer allocator.free(unit_path);
+    try linux.makePathAny(working_dir);
+    const payload = try std.fmt.allocPrint(
+        allocator,
+        \\[Unit]
+        \\Description=Spiderweb Workspace Host
+        \\After=network.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\User={s}
+        \\Environment=HOME={s}
+        \\Environment=XDG_CONFIG_HOME={s}
+        \\ExecStart={s}
+        \\WorkingDirectory={s}
+        \\Restart=on-failure
+        \\RestartSec=5
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    ,
+        .{ user.name, user.home, user.config_home, spiderweb_bin, working_dir },
+    );
+    defer allocator.free(payload);
+    try linux.writeFileAny(unit_path, payload);
+}
+
+fn gatherStatusSnapshot(allocator: std.mem.Allocator) !StatusSnapshot {
+    var user = try linux.resolveServiceUser(allocator);
+    errdefer user.deinit(allocator);
+    var config = try loadConfigSnapshot(allocator, user);
+    errdefer config.deinit(allocator);
+
+    const spiderweb_bin = try linux.resolveInstalledBinary(allocator, "spiderweb");
+    defer allocator.free(spiderweb_bin);
+    const spiderweb_config_bin = try linux.resolveInstalledBinary(allocator, "spiderweb-config");
+    defer allocator.free(spiderweb_config_bin);
+    const node_binary = try linux.resolveInstalledBinary(allocator, "spiderweb-fs-node");
+    defer allocator.free(node_binary);
+
+    const service_state = try linux.systemdState(allocator, user, service_name);
+    const node_service_state = try linux.systemdState(allocator, user, "spider-node.service");
+
+    return .{
+        .user = user,
+        .config = config,
+        .auth_present = try loadAuthPresence(allocator, user, spiderweb_config_bin),
+        .runtime_assets_present = try runtimeAssetsPresent(allocator, spiderweb_bin),
+        .local_node_binary_present = linux.pathExists(node_binary),
+        .node_service_installed = node_service_state.installed,
+        .node_service_active = node_service_state.active,
+        .service_installed = service_state.installed,
+        .service_enabled = service_state.enabled,
+        .service_active = service_state.active,
+    };
+}
+
+pub fn runInstallFlow(
+    allocator: std.mem.Allocator,
+    bind: []const u8,
+    port: u16,
+) !void {
+    try linux.ensureLinuxSupported();
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var user = try linux.resolveServiceUser(allocator);
+    defer user.deinit(allocator);
+
+    const spiderweb_bin = try linux.resolveInstalledBinary(allocator, "spiderweb");
+    defer allocator.free(spiderweb_bin);
+    const spiderweb_config_bin = try linux.resolveInstalledBinary(allocator, "spiderweb-config");
+    defer allocator.free(spiderweb_config_bin);
+
+    var first_run = std.ArrayListUnmanaged([]const u8){};
+    defer first_run.deinit(allocator);
+    try first_run.appendSlice(allocator, &.{ spiderweb_config_bin, "first-run", "--non-interactive" });
+    var first_run_result = try linux.runCommandAsServiceUser(allocator, user, first_run.items);
+    defer first_run_result.deinit(allocator);
+    if (!first_run_result.ok()) return error.CommandFailed;
+
+    var set_server = std.ArrayListUnmanaged([]const u8){};
+    defer set_server.deinit(allocator);
+    const port_text = try std.fmt.allocPrint(allocator, "{d}", .{port});
+    defer allocator.free(port_text);
+    try set_server.appendSlice(allocator, &.{ spiderweb_config_bin, "config", "set-server", "--bind", bind, "--port", port_text });
+    var set_server_result = try linux.runCommandAsServiceUser(allocator, user, set_server.items);
+    defer set_server_result.deinit(allocator);
+    if (!set_server_result.ok()) return error.CommandFailed;
+
+    const auth_created = try ensureAuthPresent(allocator, user, spiderweb_config_bin);
+
+    if (user.scope == .system) {
+        const working_dir = try std.fs.path.join(allocator, &.{ user.home, "Spiderweb" });
+        defer allocator.free(working_dir);
+        try writeSystemServiceUnit(allocator, user, spiderweb_bin, working_dir);
+
+        var reload = try linux.systemctlAction(allocator, user, &.{ "daemon-reload" });
+        defer reload.deinit(allocator);
+        if (!reload.ok()) return error.CommandFailed;
+        var enable_now = try linux.systemctlAction(allocator, user, &.{ "enable", "--now", service_name });
+        defer enable_now.deinit(allocator);
+        if (!enable_now.ok()) return error.CommandFailed;
+    } else {
+        var install_user = std.ArrayListUnmanaged([]const u8){};
+        defer install_user.deinit(allocator);
+        try install_user.appendSlice(allocator, &.{ spiderweb_config_bin, "config", "install-service" });
+        var install_result = try linux.runCommandAsServiceUser(allocator, user, install_user.items);
+        defer install_result.deinit(allocator);
+        if (!install_result.ok()) return error.CommandFailed;
+    }
+
+    try stdout.print("Spiderweb is ready on this Linux machine\n", .{});
+    try stdout.print("  Managed user: {s}\n", .{user.name});
+    try stdout.print("  Service: {s}\n", .{if (user.scope == .system) "systemd system service" else "systemd user service"});
+    try stdout.print("  Server URL: ws://{s}:{d}\n", .{ bind, port });
+    try stdout.print("  Reachability: {s}\n", .{if (linux.serverBindAllowsRemoteConnections(bind)) "other machines can connect" else "local machine only"});
+    try stdout.print("  Access auth: {s}\n", .{if (auth_created) "created during setup" else "already present"});
+    try stdout.print("  Next: spider workspace create \"Linux Workspace\"\n", .{});
+    try stdout.print("  Check health any time with: spider server doctor\n", .{});
+}
+
+pub fn executeServerInstall(allocator: std.mem.Allocator, _: args.Options, cmd: args.Command) !void {
+    var bind: []const u8 = default_bind;
+    var port: u16 = default_port;
+
+    var i: usize = 0;
+    while (i < cmd.args.len) : (i += 1) {
+        const arg = cmd.args[i];
+        if (std.mem.eql(u8, arg, "--bind")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            bind = cmd.args[i];
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--port")) {
+            i += 1;
+            if (i >= cmd.args.len) return error.InvalidArguments;
+            port = try std.fmt.parseInt(u16, cmd.args[i], 10);
+            continue;
+        }
+        return error.InvalidArguments;
+    }
+
+    try runInstallFlow(allocator, bind, port);
+}
+
+pub fn executeServerStatus(allocator: std.mem.Allocator, options: args.Options, cmd: args.Command) !void {
+    _ = options;
+    if (cmd.args.len != 0) return error.InvalidArguments;
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var status = try gatherStatusSnapshot(allocator);
+    defer status.deinit(allocator);
+
+    try stdout.print("Spiderweb server status\n", .{});
+    try stdout.print("  Managed user: {s}\n", .{status.user.name});
+    try stdout.print("  Service scope: {s}\n", .{if (status.user.scope == .system) "systemd system" else "systemd user"});
+    try stdout.print("  Service installed: {s}\n", .{if (status.service_installed) "yes" else "no"});
+    try stdout.print("  Service enabled: {s}\n", .{if (status.service_enabled) "yes" else "no"});
+    try stdout.print("  Service active: {s}\n", .{if (status.service_active) "yes" else "no"});
+    try stdout.print("  Config: {s}\n", .{status.config.config_path});
+    try stdout.print("  Server URL: ws://{s}:{d}\n", .{ status.config.bind, status.config.port });
+    try stdout.print("  Reachability: {s}\n", .{if (linux.serverBindAllowsRemoteConnections(status.config.bind)) "other machines can connect" else "local machine only"});
+    try stdout.print("  Workspace root: {s}\n", .{status.config.spider_web_root});
+    try stdout.print("  Auth present: {s}\n", .{if (status.auth_present) "yes" else "no"});
+    try stdout.print("  Runtime assets: {s}\n", .{if (status.runtime_assets_present) "ready" else "missing"});
+    try stdout.print("  Local node binary: {s}\n", .{if (status.local_node_binary_present) "present" else "missing"});
+    try stdout.print("  Linux node service: {s}\n", .{if (status.node_service_active) "active" else if (status.node_service_installed) "installed" else "not installed"});
+
+    if (status.service_active and status.auth_present and status.runtime_assets_present) {
+        try stdout.print("  Summary: ready\n", .{});
+    } else {
+        try stdout.print("  Summary: needs attention\n", .{});
+    }
+}
+
+pub fn executeServerDoctor(allocator: std.mem.Allocator, options: args.Options, cmd: args.Command) !void {
+    _ = options;
+    if (cmd.args.len != 0) return error.InvalidArguments;
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var status = try gatherStatusSnapshot(allocator);
+    defer status.deinit(allocator);
+
+    try stdout.print("Spiderweb doctor\n", .{});
+    try stdout.print("  [{s}] service installed\n", .{if (status.service_installed) "ready" else "missing"});
+    try stdout.print("  [{s}] service running\n", .{if (status.service_active) "ready" else "missing"});
+    try stdout.print("  [{s}] access auth\n", .{if (status.auth_present) "ready" else "missing"});
+    try stdout.print("  [{s}] runtime assets\n", .{if (status.runtime_assets_present) "ready" else "missing"});
+    try stdout.print("  [{s}] reachability ({s})\n", .{
+        if (linux.serverBindAllowsRemoteConnections(status.config.bind)) "ready" else "local-only",
+        status.config.bind,
+    });
+    try stdout.print("  [{s}] local node binary\n", .{if (status.local_node_binary_present) "ready" else "missing"});
+
+    if (status.service_active and status.auth_present and status.runtime_assets_present) {
+        try stdout.print("  Result: server ready\n", .{});
+        try stdout.print("  Next: spider workspace create \"Linux Workspace\"\n", .{});
+    } else {
+        try stdout.print("  Result: repair needed\n", .{});
+        try stdout.print("  Suggested next step: spider server install\n", .{});
+    }
+}
+
+pub fn executeServerRemove(allocator: std.mem.Allocator, _: args.Options, cmd: args.Command) !void {
+    if (cmd.args.len != 0) return error.InvalidArguments;
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    var user = try linux.resolveServiceUser(allocator);
+    defer user.deinit(allocator);
+    const spiderweb_config_bin = try linux.resolveInstalledBinary(allocator, "spiderweb-config");
+    defer allocator.free(spiderweb_config_bin);
+
+    if (user.scope == .system) {
+        var disable = try linux.systemctlAction(allocator, user, &.{ "disable", "--now", service_name });
+        defer disable.deinit(allocator);
+        const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
+        defer allocator.free(unit_path);
+        if (linux.pathExists(unit_path)) {
+            std.fs.deleteFileAbsolute(unit_path) catch {};
+        }
+        var reload = try linux.systemctlAction(allocator, user, &.{ "daemon-reload" });
+        defer reload.deinit(allocator);
+    } else {
+        var uninstall = std.ArrayListUnmanaged([]const u8){};
+        defer uninstall.deinit(allocator);
+        try uninstall.appendSlice(allocator, &.{ spiderweb_config_bin, "config", "uninstall-service" });
+        var uninstall_result = try linux.runCommandAsServiceUser(allocator, user, uninstall.items);
+        defer uninstall_result.deinit(allocator);
+        if (!uninstall_result.ok()) return error.CommandFailed;
+    }
+
+    try stdout.print("Spiderweb service removed. Config and auth were left in place.\n", .{});
+}
+
+pub fn runInstallWizard(allocator: std.mem.Allocator) !void {
+    tui.printInfo("This sets up Spiderweb as a Linux service on this machine.");
+    const bind = try tui.prompt(allocator, "Spiderweb bind address", default_bind);
+    defer allocator.free(bind);
+    const port_text = try tui.prompt(allocator, "Spiderweb port", "18790");
+    defer allocator.free(port_text);
+    const port = try std.fmt.parseInt(u16, port_text, 10);
+    try runInstallFlow(allocator, bind, port);
+}

--- a/src/cli/commands/server.zig
+++ b/src/cli/commands/server.zig
@@ -165,6 +165,7 @@ fn writeSystemServiceUnit(
     const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
     defer allocator.free(unit_path);
     try linux.makePathAny(working_dir);
+    try linux.ensureOwnedByServiceUser(allocator, user, working_dir);
     const payload = try std.fmt.allocPrint(
         allocator,
         \\[Unit]
@@ -379,6 +380,7 @@ pub fn executeServerRemove(allocator: std.mem.Allocator, _: args.Options, cmd: a
     if (user.scope == .system) {
         var disable = try linux.systemctlAction(allocator, user, &.{ "disable", "--now", service_name });
         defer disable.deinit(allocator);
+        if (!disable.ok()) return error.CommandFailed;
         const unit_path = try linux.resolveSystemdUnitPath(allocator, user, service_name);
         defer allocator.free(unit_path);
         if (linux.pathExists(unit_path)) {
@@ -386,6 +388,7 @@ pub fn executeServerRemove(allocator: std.mem.Allocator, _: args.Options, cmd: a
         }
         var reload = try linux.systemctlAction(allocator, user, &.{ "daemon-reload" });
         defer reload.deinit(allocator);
+        if (!reload.ok()) return error.CommandFailed;
     } else {
         var uninstall = std.ArrayListUnmanaged([]const u8){};
         defer uninstall.deinit(allocator);

--- a/src/cli/docs/01-overview.md
+++ b/src/cli/docs/01-overview.md
@@ -59,6 +59,7 @@ spider --help
 - `session restore [agent_id]` - Attach the latest persisted session
 - `node list` - List registered nodes
 - `node info <node_id>` - Show node details
+- `node invite-create` - Create an invite token for a Linux node
 - `node join-request <node_name> [fs_url]` - Submit pending node join request
 - `node pending` - List pending node join requests
 - `node approve <request_id>` - Approve pending node join request
@@ -66,6 +67,14 @@ spider --help
 - `node service-get <node_id>` - Show node service catalog
 - `node service-upsert <node_id> <node_secret>` - Update node service catalog metadata
 - `node service-runtime <node_id> <service_id> <action>` - Read/write runtime control files for a service mount
+- `server install` - Install or update Spiderweb as a Linux service
+- `server status` - Show Linux Spiderweb status
+- `server doctor` - Show Linux Spiderweb health and next step
+- `server remove` - Remove the Linux Spiderweb service
+- `local-node install` - Install Linux node scaffolding
+- `local-node connect` - Connect this Linux machine to another Spiderweb
+- `local-node status` - Show Linux node status
+- `local-node remove` - Remove the Linux node service and local config
 - `workspace status [workspace_id]` - Show active workspace mounts
 - `auth status` - Show Spiderweb auth token status (admin only)
 - `auth rotate <admin|user>` - Rotate Spiderweb auth token (admin only)
@@ -92,15 +101,22 @@ spider --help
 
 ## Interactive Mode
 
-Interactive mode entry exists, but the REPL is not implemented yet.
+On Linux, running `spider` with no subcommand from a real terminal opens the guided Linux home.
+
+That guided home offers:
+
+- `Host Spiderweb Here`
+- `Connect This Linux Machine`
+- `Status / Repair`
+
+Use `spider --interactive` only when you explicitly want the REPL path.
 
 Current behavior:
 
 ```
-spider --url ws://100.101.192.123:18790
+spider
 
-Interactive mode not yet implemented.
-Use command mode for now.
+Spider Linux Home
 ```
 
 ## Design Philosophy

--- a/src/cli/docs/02-options.md
+++ b/src/cli/docs/02-options.md
@@ -54,7 +54,7 @@ spider --operator-token op-secret workspace create "Game AI"
 ### `--interactive`
 Start interactive REPL mode instead of running a single command.
 
-Note: the interactive REPL is not implemented yet; command mode is currently required.
+On Linux, running `spider` with no subcommand opens the guided onboarding home by default. Use `--interactive` when you explicitly want the REPL instead.
 
 **Examples:**
 ```bash

--- a/src/cli/linux_support.zig
+++ b/src/cli/linux_support.zig
@@ -1,0 +1,333 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const ServiceScope = enum {
+    system,
+    user,
+};
+
+pub const CommandResult = struct {
+    stdout: []u8,
+    stderr: []u8,
+    term: std.process.Child.Term,
+
+    pub fn deinit(self: *CommandResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+        self.* = undefined;
+    }
+
+    pub fn ok(self: CommandResult) bool {
+        return switch (self.term) {
+            .Exited => |code| code == 0,
+            else => false,
+        };
+    }
+
+    pub fn summary(self: CommandResult, fallback: []const u8) []const u8 {
+        const stdout_text = std.mem.trim(u8, self.stdout, " \t\r\n");
+        if (stdout_text.len > 0) return stdout_text;
+        const stderr_text = std.mem.trim(u8, self.stderr, " \t\r\n");
+        if (stderr_text.len > 0) return stderr_text;
+        return fallback;
+    }
+};
+
+pub const ServiceUser = struct {
+    name: []u8,
+    home: []u8,
+    config_home: []u8,
+    scope: ServiceScope,
+
+    pub fn deinit(self: *ServiceUser, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.home);
+        allocator.free(self.config_home);
+        self.* = undefined;
+    }
+};
+
+pub fn ensureLinuxSupported() !void {
+    if (builtin.os.tag != .linux) return error.UnsupportedPlatform;
+}
+
+pub fn pathExists(path: []const u8) bool {
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.accessAbsolute(path, .{}) catch return false;
+        return true;
+    }
+    std.fs.cwd().access(path, .{}) catch return false;
+    return true;
+}
+
+pub fn ensureParentPath(path: []const u8) !void {
+    const parent = std.fs.path.dirname(path) orelse return;
+    if (parent.len == 0) return;
+
+    if (std.fs.path.isAbsolute(parent)) {
+        var root = try std.fs.openDirAbsolute("/", .{});
+        defer root.close();
+        const relative = std.mem.trimLeft(u8, parent, "/");
+        if (relative.len == 0) return;
+        try root.makePath(relative);
+        return;
+    }
+
+    try std.fs.cwd().makePath(parent);
+}
+
+pub fn makePathAny(path: []const u8) !void {
+    if (path.len == 0) return;
+    if (std.fs.path.isAbsolute(path)) {
+        var root = try std.fs.openDirAbsolute("/", .{});
+        defer root.close();
+        const relative = std.mem.trimLeft(u8, path, "/");
+        if (relative.len == 0) return;
+        try root.makePath(relative);
+        return;
+    }
+    try std.fs.cwd().makePath(path);
+}
+
+pub fn writeFileAny(path: []const u8, payload: []const u8) !void {
+    try ensureParentPath(path);
+    if (std.fs.path.isAbsolute(path)) {
+        var root = try std.fs.openDirAbsolute("/", .{});
+        defer root.close();
+        const relative = std.mem.trimLeft(u8, path, "/");
+        if (relative.len == 0) return error.InvalidArguments;
+        try root.writeFile(.{ .sub_path = relative, .data = payload });
+        return;
+    }
+    try std.fs.cwd().writeFile(.{ .sub_path = path, .data = payload });
+}
+
+pub fn readFileAllocAny(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    max_bytes: usize,
+) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        var file = try std.fs.openFileAbsolute(path, .{});
+        defer file.close();
+        return file.readToEndAlloc(allocator, max_bytes);
+    }
+    var file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    return file.readToEndAlloc(allocator, max_bytes);
+}
+
+fn resolveUserNameFromEnv(allocator: std.mem.Allocator) ![]u8 {
+    if (std.process.getEnvVarOwned(allocator, "SUDO_USER") catch null) |value| {
+        if (value.len > 0) return value;
+        allocator.free(value);
+    }
+    if (std.process.getEnvVarOwned(allocator, "USER") catch null) |value| {
+        if (value.len > 0) return value;
+        allocator.free(value);
+    }
+
+    var result = try runCommandCapture(allocator, &.{ "id", "-un" });
+    defer result.deinit(allocator);
+    if (!result.ok()) return error.CommandFailed;
+    return allocator.dupe(u8, std.mem.trim(u8, result.stdout, " \t\r\n"));
+}
+
+fn resolveHomeForUser(allocator: std.mem.Allocator, user_name: []const u8) ![]u8 {
+    const current_user = std.process.getEnvVarOwned(allocator, "USER") catch null;
+    defer if (current_user) |value| allocator.free(value);
+    if (current_user) |value| {
+        if (std.mem.eql(u8, value, user_name)) {
+            if (std.process.getEnvVarOwned(allocator, "HOME") catch null) |home| {
+                if (home.len > 0) return home;
+                allocator.free(home);
+            }
+        }
+    }
+
+    var result = try runCommandCapture(allocator, &.{ "getent", "passwd", user_name });
+    defer result.deinit(allocator);
+    if (!result.ok()) return error.CommandFailed;
+    const line = std.mem.trim(u8, result.stdout, " \t\r\n");
+    var fields = std.mem.splitScalar(u8, line, ':');
+    var index: usize = 0;
+    while (fields.next()) |field| : (index += 1) {
+        if (index == 5 and field.len > 0) return allocator.dupe(u8, field);
+    }
+    return error.CommandFailed;
+}
+
+pub fn resolveServiceUser(allocator: std.mem.Allocator) !ServiceUser {
+    try ensureLinuxSupported();
+    const user_name = try resolveUserNameFromEnv(allocator);
+    errdefer allocator.free(user_name);
+    const home = try resolveHomeForUser(allocator, user_name);
+    errdefer allocator.free(home);
+    const config_home = try std.fs.path.join(allocator, &.{ home, ".config" });
+    errdefer allocator.free(config_home);
+    return .{
+        .name = user_name,
+        .home = home,
+        .config_home = config_home,
+        .scope = if (std.posix.getuid() == 0) .system else .user,
+    };
+}
+
+pub fn resolveSpiderConfigDir(allocator: std.mem.Allocator, user: ServiceUser) ![]u8 {
+    return std.fs.path.join(allocator, &.{ user.config_home, "spider" });
+}
+
+pub fn resolveSpiderwebConfigPath(allocator: std.mem.Allocator, user: ServiceUser) ![]u8 {
+    return std.fs.path.join(allocator, &.{ user.config_home, "spiderweb", "config.json" });
+}
+
+pub fn resolveLinuxNodeConfigPath(allocator: std.mem.Allocator, user: ServiceUser) ![]u8 {
+    return std.fs.path.join(allocator, &.{ user.config_home, "spider", "linux-node.json" });
+}
+
+pub fn resolveLinuxNodeStatePath(allocator: std.mem.Allocator, user: ServiceUser) ![]u8 {
+    return std.fs.path.join(allocator, &.{ user.config_home, "spider", "linux-node-state.json" });
+}
+
+pub fn resolveSystemdUnitPath(
+    allocator: std.mem.Allocator,
+    user: ServiceUser,
+    unit_name: []const u8,
+) ![]u8 {
+    return switch (user.scope) {
+        .system => std.fs.path.join(allocator, &.{ "/etc", "systemd", "system", unit_name }),
+        .user => std.fs.path.join(allocator, &.{ user.home, ".config", "systemd", "user", unit_name }),
+    };
+}
+
+pub fn resolveInstalledBinary(allocator: std.mem.Allocator, binary_name: []const u8) ![]u8 {
+    const self_exe = try std.fs.selfExePathAlloc(allocator);
+    defer allocator.free(self_exe);
+    const self_dir = std.fs.path.dirname(self_exe) orelse ".";
+    const sibling = try std.fs.path.join(allocator, &.{ self_dir, binary_name });
+    errdefer allocator.free(sibling);
+    if (pathExists(sibling)) return sibling;
+    allocator.free(sibling);
+    return resolveBinaryOnPath(allocator, binary_name);
+}
+
+pub fn resolveBinaryOnPath(allocator: std.mem.Allocator, binary_name: []const u8) ![]u8 {
+    if (std.mem.indexOfScalar(u8, binary_name, '/')) |_| return allocator.dupe(u8, binary_name);
+
+    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return allocator.dupe(u8, binary_name);
+    defer allocator.free(path_env);
+    var it = std.mem.splitScalar(u8, path_env, ':');
+    while (it.next()) |segment| {
+        if (segment.len == 0) continue;
+        const candidate = try std.fs.path.join(allocator, &.{ segment, binary_name });
+        errdefer allocator.free(candidate);
+        if (pathExists(candidate)) return candidate;
+        allocator.free(candidate);
+    }
+    return allocator.dupe(u8, binary_name);
+}
+
+pub fn runCommandCapture(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) !CommandResult {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv,
+        .max_output_bytes = 256 * 1024,
+    });
+    return .{
+        .stdout = result.stdout,
+        .stderr = result.stderr,
+        .term = result.term,
+    };
+}
+
+fn privilegeDropTool(allocator: std.mem.Allocator) ![]const u8 {
+    const sudo_path = try resolveBinaryOnPath(allocator, "sudo");
+    defer allocator.free(sudo_path);
+    if (pathExists(sudo_path)) return "sudo";
+    const runuser_path = try resolveBinaryOnPath(allocator, "runuser");
+    defer allocator.free(runuser_path);
+    if (pathExists(runuser_path)) return "runuser";
+    return error.CommandFailed;
+}
+
+pub fn runCommandAsServiceUser(
+    allocator: std.mem.Allocator,
+    user: ServiceUser,
+    argv: []const []const u8,
+) !CommandResult {
+    if (std.posix.getuid() != 0) return runCommandCapture(allocator, argv);
+    if (std.mem.eql(u8, user.name, "root")) return runCommandCapture(allocator, argv);
+
+    const drop_tool = try privilegeDropTool(allocator);
+    var cmd = std.ArrayListUnmanaged([]const u8){};
+    defer cmd.deinit(allocator);
+    if (std.mem.eql(u8, drop_tool, "sudo")) {
+        try cmd.appendSlice(allocator, &.{ "sudo", "-u", user.name, "-H", "--" });
+    } else {
+        try cmd.appendSlice(allocator, &.{ "runuser", "-u", user.name, "--" });
+    }
+    try cmd.appendSlice(allocator, argv);
+    return runCommandCapture(allocator, cmd.items);
+}
+
+pub fn ensureOwnedByServiceUser(
+    allocator: std.mem.Allocator,
+    user: ServiceUser,
+    path: []const u8,
+) !void {
+    if (std.posix.getuid() != 0) return;
+    if (std.mem.eql(u8, user.name, "root")) return;
+    if (!pathExists(path)) return;
+
+    var result = try runCommandCapture(allocator, &.{ "chown", "-R", user.name, path });
+    defer result.deinit(allocator);
+    if (!result.ok()) return error.CommandFailed;
+}
+
+pub fn systemctlAction(
+    allocator: std.mem.Allocator,
+    user: ServiceUser,
+    action_args: []const []const u8,
+) !CommandResult {
+    var argv = std.ArrayListUnmanaged([]const u8){};
+    defer argv.deinit(allocator);
+    try argv.append(allocator, "systemctl");
+    if (user.scope == .user) try argv.append(allocator, "--user");
+    try argv.appendSlice(allocator, action_args);
+    return runCommandCapture(allocator, argv.items);
+}
+
+pub fn systemdState(
+    allocator: std.mem.Allocator,
+    user: ServiceUser,
+    unit_name: []const u8,
+) !struct { installed: bool, enabled: bool, active: bool } {
+    const unit_path = try resolveSystemdUnitPath(allocator, user, unit_name);
+    defer allocator.free(unit_path);
+    const installed = pathExists(unit_path);
+
+    var enabled_result = try systemctlAction(allocator, user, &.{ "is-enabled", unit_name });
+    defer enabled_result.deinit(allocator);
+    var active_result = try systemctlAction(allocator, user, &.{ "is-active", unit_name });
+    defer active_result.deinit(allocator);
+
+    const enabled_text = std.mem.trim(u8, enabled_result.stdout, " \t\r\n");
+    const active_text = std.mem.trim(u8, active_result.stdout, " \t\r\n");
+
+    return .{
+        .installed = installed,
+        .enabled = installed and std.mem.eql(u8, enabled_text, "enabled"),
+        .active = installed and std.mem.eql(u8, active_text, "active"),
+    };
+}
+
+pub fn serverBindAllowsRemoteConnections(bind: []const u8) bool {
+    const trimmed = std.mem.trim(u8, bind, " \t\r\n");
+    if (trimmed.len == 0) return false;
+    return !std.mem.eql(u8, trimmed, "127.0.0.1") and
+        !std.mem.eql(u8, trimmed, "localhost") and
+        !std.mem.eql(u8, trimmed, "::1");
+}

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -2,6 +2,7 @@
 // Parses arguments and dispatches to per-noun command modules.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const args = @import("args.zig");
 const logger = @import("ziggy-core").utils.logger;
 const ctx = @import("client_context.zig");
@@ -17,7 +18,10 @@ const cmd_chat = @import("commands/chat.zig");
 const cmd_fs = @import("commands/fs.zig");
 const cmd_package = @import("commands/package.zig");
 const cmd_complete = @import("commands/complete.zig");
+const cmd_server = @import("commands/server.zig");
+const cmd_local_node = @import("commands/local_node.zig");
 const repl = @import("repl.zig");
+const linux_onboarding = @import("wizards/linux_onboarding.zig");
 
 // ── Interactive REPL ──────────────────────────────────────────────────────────
 
@@ -87,6 +91,7 @@ fn executeCommand(allocator: std.mem.Allocator, options: args.Options, cmd: args
                 .list => try cmd_node.executeNodeList(allocator, options, cmd),
                 .info => try cmd_node.executeNodeInfo(allocator, options, cmd),
                 .pending => try cmd_node.executeNodePendingList(allocator, options, cmd),
+                .invite_create => try cmd_node.executeNodeInviteCreate(allocator, options, cmd),
                 .approve => try cmd_node.executeNodeApprove(allocator, options, cmd),
                 .deny => try cmd_node.executeNodeDeny(allocator, options, cmd),
                 .join_request => try cmd_node.executeNodeJoinRequest(allocator, options, cmd),
@@ -96,6 +101,30 @@ fn executeCommand(allocator: std.mem.Allocator, options: args.Options, cmd: args
                 .watch => try cmd_node.executeNodeServiceWatch(allocator, options, cmd),
                 else => {
                     logger.err("Unknown node verb", .{});
+                    return error.InvalidArguments;
+                },
+            }
+        },
+        .server => {
+            switch (cmd.verb) {
+                .install => try cmd_server.executeServerInstall(allocator, options, cmd),
+                .status => try cmd_server.executeServerStatus(allocator, options, cmd),
+                .doctor => try cmd_server.executeServerDoctor(allocator, options, cmd),
+                .remove => try cmd_server.executeServerRemove(allocator, options, cmd),
+                else => {
+                    logger.err("Unknown server verb", .{});
+                    return error.InvalidArguments;
+                },
+            }
+        },
+        .local_node => {
+            switch (cmd.verb) {
+                .install => try cmd_local_node.executeLocalNodeInstall(allocator, options, cmd),
+                .connect => try cmd_local_node.executeLocalNodeConnect(allocator, options, cmd),
+                .status => try cmd_local_node.executeLocalNodeStatus(allocator, options, cmd),
+                .remove => try cmd_local_node.executeLocalNodeRemove(allocator, options, cmd),
+                else => {
+                    logger.err("Unknown local-node verb", .{});
                     return error.InvalidArguments;
                 },
             }
@@ -231,7 +260,15 @@ pub fn run(allocator: std.mem.Allocator) !void {
     if (options.command) |cmd| {
         try executeCommand(allocator, options, cmd);
     } else if (options.interactive) {
-        try runInteractive(allocator, options);
+        if (!options.interactive_explicit) {
+            if (builtin.os.tag == .linux and std.fs.File.stdin().isTty() and std.fs.File.stdout().isTty()) {
+                try linux_onboarding.run(allocator);
+            } else {
+                args.printHelp();
+            }
+        } else {
+            try runInteractive(allocator, options);
+        }
     } else {
         args.printHelp();
     }

--- a/src/cli/repl.zig
+++ b/src/cli/repl.zig
@@ -31,6 +31,8 @@ const cmd_auth = @import("commands/auth.zig");
 const cmd_fs = @import("commands/fs.zig");
 const cmd_package = @import("commands/package.zig");
 const cmd_complete = @import("commands/complete.zig");
+const cmd_server = @import("commands/server.zig");
+const cmd_local_node = @import("commands/local_node.zig");
 
 // ── History ───────────────────────────────────────────────────────────────────
 
@@ -139,6 +141,7 @@ fn dispatchCommand(
             .list => try cmd_node.executeNodeList(allocator, options, cmd),
             .info => try cmd_node.executeNodeInfo(allocator, options, cmd),
             .pending => try cmd_node.executeNodePendingList(allocator, options, cmd),
+            .invite_create => try cmd_node.executeNodeInviteCreate(allocator, options, cmd),
             .approve => try cmd_node.executeNodeApprove(allocator, options, cmd),
             .deny => try cmd_node.executeNodeDeny(allocator, options, cmd),
             .join_request => try cmd_node.executeNodeJoinRequest(allocator, options, cmd),
@@ -147,6 +150,20 @@ fn dispatchCommand(
             .service_runtime => try cmd_node.executeNodeServiceRuntime(allocator, options, cmd),
             .watch => try cmd_node.executeNodeServiceWatch(allocator, options, cmd),
             else => try stdout.print("Unknown node verb\n", .{}),
+        },
+        .server => switch (verb) {
+            .install => try cmd_server.executeServerInstall(allocator, options, cmd),
+            .status => try cmd_server.executeServerStatus(allocator, options, cmd),
+            .doctor => try cmd_server.executeServerDoctor(allocator, options, cmd),
+            .remove => try cmd_server.executeServerRemove(allocator, options, cmd),
+            else => try stdout.print("Unknown server verb\n", .{}),
+        },
+        .local_node => switch (verb) {
+            .install => try cmd_local_node.executeLocalNodeInstall(allocator, options, cmd),
+            .connect => try cmd_local_node.executeLocalNodeConnect(allocator, options, cmd),
+            .status => try cmd_local_node.executeLocalNodeStatus(allocator, options, cmd),
+            .remove => try cmd_local_node.executeLocalNodeRemove(allocator, options, cmd),
+            else => try stdout.print("Unknown local-node verb\n", .{}),
         },
         .session => switch (verb) {
             .list => try cmd_session.executeSessionList(allocator, options, cmd),
@@ -209,6 +226,8 @@ fn printReplHelp(stdout: anytype) void {
     stdout.writeAll(
         \\  /workspace list|use|up|status|doctor|info|...
         \\  /node list|info|pending|approve|deny|...
+        \\  /server install|status|doctor|remove
+        \\  /local-node install|connect|status|remove
         \\  /session list|status|attach|close|history
         \\  /agent list|info
         \\  /package list|catalog|updates|update|update-all|get|install|channel-get|channel-set|channel-clear|switch|rollback|enable|disable|remove

--- a/src/cli/wizards/linux_onboarding.zig
+++ b/src/cli/wizards/linux_onboarding.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const tui = @import("../tui.zig");
+const server = @import("../commands/server.zig");
+const local_node = @import("../commands/local_node.zig");
+
+pub fn run(allocator: std.mem.Allocator) !void {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    tui.writeAnsi(stdout, tui.BOLD ++ tui.BLUE);
+    try stdout.writeAll("\n╔══════════════════════════════════════╗\n");
+    try stdout.writeAll("║        Spider Linux Home             ║\n");
+    try stdout.writeAll("╚══════════════════════════════════════╝\n");
+    tui.writeAnsi(stdout, tui.RESET);
+    tui.printInfo("Choose what this Linux machine should do first.");
+    try stdout.writeAll("\n");
+    try stdout.writeAll("  1. Host Spiderweb Here       Run the server on this machine\n");
+    try stdout.writeAll("  2. Connect This Linux Machine  Add this machine to another Spiderweb\n");
+    try stdout.writeAll("  3. Status / Repair           Check what is installed and what needs attention\n");
+
+    const options = [_][]const u8{
+        "Host Spiderweb Here",
+        "Connect This Linux Machine",
+        "Status / Repair",
+    };
+
+    const choice = try tui.select(allocator, "Linux setup", &options);
+    switch (choice) {
+        0 => try server.runInstallWizard(allocator),
+        1 => try local_node.runConnectWizard(allocator),
+        2 => try printStatusRepair(allocator),
+        else => unreachable,
+    }
+}
+
+fn printStatusRepair(allocator: std.mem.Allocator) !void {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    try stdout.writeAll("\n");
+    tui.printStep(1, 2, "Spiderweb server");
+    try server.executeServerStatus(allocator, .{}, .{
+        .noun = .server,
+        .verb = .status,
+        .args = &.{},
+    });
+    try stdout.writeAll("\n");
+    try server.executeServerDoctor(allocator, .{}, .{
+        .noun = .server,
+        .verb = .doctor,
+        .args = &.{},
+    });
+
+    try stdout.writeAll("\n");
+    tui.printStep(2, 2, "Linux node");
+    try local_node.executeLocalNodeStatus(allocator, .{}, .{
+        .noun = .local_node,
+        .verb = .status,
+        .args = &.{},
+    });
+}


### PR DESCRIPTION
## Summary
- add Linux-first `spider server` and `spider local-node` flows plus a no-arg onboarding home
- polish Linux pairing/admin commands and repair ownership for system-installed node state
- update CLI help, completions, and built-in docs for the new Linux operator path

## Validation
- `zig build test`
- Ubuntu arm64 OrbStack VM:
  - `sudo spider server install --bind 0.0.0.0 --port 18790`
  - `sudo spider server status`
  - `sudo spider server doctor`
  - `sudo spider local-node connect --control-url ... --invite-token ... --control-auth-token ...`
  - `sudo spider local-node connect --control-url ... --request-approval --control-auth-token ...`
  - `sudo spider local-node status`
  - reboot persistence for `spider-node.service`
- `spider --help`

## Notes
- Ubuntu amd64 OrbStack validation is still blocked by a Zig x86_64 build-runner crash in the VM, even after upgrading to Zig 0.15.2 and copying the repo onto the VM's local disk.
